### PR TITLE
new assertions for testModel

### DIFF
--- a/repository/OpenPonk-Core/OPDiagramTest.class.st
+++ b/repository/OpenPonk-Core/OPDiagramTest.class.st
@@ -101,7 +101,15 @@ OPDiagramTest >> testFromJsonComplex [
 OPDiagramTest >> testModel [
 	| model project |
 	model := OPTestContainerModel new.
-	view := OPDiagram new model: model.
+	view := OPDiagram new.
+	self assert: view modelType equals: 'UndefinedObject'.
+	self assert: view model isNil.
+	self assert: view modelName equals: 'UndefinedObject'.
+	view model: model.
+	self assert: view modelType equals: 'OPTestContainerModel'.
+	self assert: view model class equals: OPTestContainerModel.
+	self assert: view model name equals: 'container'.
+	self assert: view modelName equals: 'container'.
 	self assert: view model equals: model
 ]
 


### PR DESCRIPTION
I submit this pull request to suggest new assertions for `OPDiagramTest >> testModel`.

The assertions in lines 105 to 107 verify the state of a freshly initialized object (where `model` is nil). After setting the model to an appropriate value, the assertions in lines 109 to 112 verify the public API through the accessor methods.

Note that these suggestions are adapted from a test amplification tool called SmallAmp (https://github.com/mabdi/small-amp). SmallAmp executes existing tests, sees which parts of the class under test are not covered and then suggests improvements on the test methods.

I hope you will accept this pull request. It would illustrate that SmallAmp makes relevant suggestions.

Mehrdad Abdi.
