### PR TITLE
Modified OPRenameElementCommand to use UIManager (to be confirmable by enter key)

### DIFF
--- a/repository/OpenPonk-Core/OPRenameElementCommand.class.st
+++ b/repository/OpenPonk-Core/OPRenameElementCommand.class.st
@@ -24,14 +24,10 @@ Class {
 { #category : #execute }
 OPRenameElementCommand >> execute [
 
-	| dialog result window |
-	dialog := SpRequestDialog new.
-	dialog label: 'Enter name'.
-	window := dialog openBlockedDialog.
-	result := dialog text.
+	| result |
+	result := UIManager default request: 'Enter a name' initialAnswer: (controller model name).
 	result ifNil: [ ^ self ].
 	result ifEmpty: [ ^ self ].
-	window cancelled ifTrue: [ ^ self ].
 	controller model name: result.
-	controller model announcer announce: OPElementRenamed new
+	controller model announcer announce: OPElementRenamed new.
 ]


### PR DESCRIPTION
It also shows the previous value as initial, which is a very handy feature when renaming elements with longer names.

For the most part fixes #76.